### PR TITLE
Fix typo in Color validation message

### DIFF
--- a/TacoSpigot-API/src/main/java/org/bukkit/Color.java
+++ b/TacoSpigot-API/src/main/java/org/bukkit/Color.java
@@ -142,7 +142,7 @@ public final class Color implements ConfigurationSerializable {
      *     bits
      */
     public static Color fromRGB(int rgb) throws IllegalArgumentException {
-        Validate.isTrue((rgb >> 24) == 0, "Extrenuous data in: ", rgb);
+        Validate.isTrue((rgb >> 24) == 0, "Extraneous data in: ", rgb);
         return fromRGB(rgb >> 16 & BIT_MASK, rgb >> 8 & BIT_MASK, rgb >> 0 & BIT_MASK);
     }
 
@@ -156,7 +156,7 @@ public final class Color implements ConfigurationSerializable {
      *     bits
      */
     public static Color fromBGR(int bgr) throws IllegalArgumentException {
-        Validate.isTrue((bgr >> 24) == 0, "Extrenuous data in: ", bgr);
+        Validate.isTrue((bgr >> 24) == 0, "Extraneous data in: ", bgr);
         return fromBGR(bgr >> 16 & BIT_MASK, bgr >> 8 & BIT_MASK, bgr >> 0 & BIT_MASK);
     }
 


### PR DESCRIPTION
## Summary
- fix a typo in the validation error message in `Color.fromRGB()` and `Color.fromBGR()`

## Testing
- `grep -n "Extraneous" TacoSpigot-API/src/main/java/org/bukkit/Color.java`

------
https://chatgpt.com/codex/tasks/task_e_68451aa62c188325a0275280288d31ea